### PR TITLE
Fix for #3 and github workflow to test for working rust build

### DIFF
--- a/.github/workflows/generate-rust.yaml
+++ b/.github/workflows/generate-rust.yaml
@@ -1,0 +1,33 @@
+name: generate_rust
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - "templates/rust/**"
+  pull_request:
+    branches: [ master ]
+    paths:
+    - "templates/rust/**"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-20_04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install clippy
+      run: rustup component add clippy
+    - name: install wapc
+      run: sudo npm install -g git+https://github.com/wapc/cli.git#master
+    - name: generate
+      run: wapc new rust gen-rust
+    - name: build
+      run: make
+      working-directory: $GITHUB_WORKSPACE/gen-rust
+    - name: clippy_check
+      run: cargo clippy
+      working-directory: $GITHUB_WORKSPACE/gen-rust
+

--- a/.github/workflows/generate_rust.yml
+++ b/.github/workflows/generate_rust.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   cargo_check:
-    runs-on: ubuntu-20_04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install clippy

--- a/.github/workflows/generate_rust.yml
+++ b/.github/workflows/generate_rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
     paths:
     - "templates/rust/**"
+    - .github/workflows/generate_rust.yml
   pull_request:
     branches: [ master ]
     paths:
@@ -24,10 +25,11 @@ jobs:
       run: sudo npm install -g git+https://github.com/wapc/cli.git#master
     - name: generate
       run: wapc new rust gen-rust
-    - name: build
+      working-directory: /tmp
+    - name: build from generated template
       run: make
-      working-directory: $GITHUB_WORKSPACE/gen-rust
+      working-directory: /tmp/gen-rust
     - name: clippy_check
       run: cargo clippy
-      working-directory: $GITHUB_WORKSPACE/gen-rust
+      working-directory: /tmp/gen-rust
 

--- a/.github/workflows/generate_rust.yml
+++ b/.github/workflows/generate_rust.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - name: Add wasm32-unknown-unknown
+      run: rustup target add wasm32-unknown-unknown
     - name: install clippy
       run: rustup component add clippy
     - name: install wapc

--- a/templates/rust/Makefile
+++ b/templates/rust/Makefile
@@ -8,8 +8,7 @@ codegen:
 	wapc generate codegen.yaml
 
 build:
-	cargo build --target wasm32-unknown-unknown --release
-	mkdir -p build && cp target/wasm32-unknown-unknown/release/*.wasm build/
+	cargo build --release
 
 # Rust builds accrue disk space over time (specifically the target directory),
 # so running `make clean` should be done periodically.


### PR DESCRIPTION

I changed the `build` make target so it doesn't generate wasm32, and doesn't look for the wasmfile.
I also added a github workflow that verifies that the rust template complies without errors,
however, the workflow run fails because `wapc new` doesn't use it.

I tried `wapc new _absolute_path_to_template_` but wapc expects the template to be relative to `$HOME/.wapc/templates`